### PR TITLE
Dockerfile: Set home dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt -y update && apt -y upgrade && \
         tzdata \
         wget
 
-RUN useradd -r fact
+RUN useradd -r --no-create-home -d /var/log/fact fact
 RUN printf 'fact	ALL=(ALL:ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/99_fact
 
 RUN mkdir /opt/FACT_core && chown fact: /opt/FACT_core


### PR DESCRIPTION
This fixes problems with binwalk that assumes that $HOME is set to an existing
directory.
See [1]

[1] https://github.com/ReFirmLabs/binwalk/issues/571

Closes https://github.com/fkie-cad/FACT_docker/issues/5