### PR TITLE
added docker volume for storing the postgres DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ ./start.py compose-env \
     # Have a look if it looks right
 $ eval $(./start.py compose-env --firmware-file-storage-dir path_to_fw_data_dir)
 $ export FACT_DOCKER_POSTGRES_PASSWORD=mypassword
-$ docker volume create postgres_data
+$ docker volume create fact_postgres_data
 $ docker-compose up -d database
 # Wait some seconds until the db is ready
 $ ./start.py initialize-db \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $ ./start.py compose-env \
     # Have a look if it looks right
 $ eval $(./start.py compose-env --firmware-file-storage-dir path_to_fw_data_dir)
 $ export FACT_DOCKER_POSTGRES_PASSWORD=mypassword
+$ docker volume create postgres_data
 $ docker-compose up -d database
 # Wait some seconds until the db is ready
 $ ./start.py initialize-db \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,3 +91,4 @@ networks:
 
 volumes:
   postgres_data:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
         POSTGRES_PASSWORD: "${FACT_DOCKER_POSTGRES_PASSWORD}"
     expose:
       - 5432
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   redis:
     image: redis
@@ -86,3 +88,6 @@ services:
 
 networks:
   fact-network: {}
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     expose:
       - 5432
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - fact_postgres_data:/var/lib/postgresql/data
 
   redis:
     image: redis
@@ -90,5 +90,5 @@ networks:
   fact-network: {}
 
 volumes:
-  postgres_data:
+  fact_postgres_data:
     external: true


### PR DESCRIPTION
addresses the problems with lost database contents from issue #27

- creates a volume for storing the postgres DB data outside and independently of the postgres container so that replacing the container shouldn't lead to loss of analysis data