### PR TITLE
docs(readme): Add note to create directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ docker pull ghcr.io/fkie-cad/fact-core-scripts:4.0.1
 $ ./start.py pull
 $ ./start.py compose-env \
     --firmware-file-storage-dir path_to_fw_data_dir
-    # Have a look if it looks right
+    # Have a look if it looks right and create directories when needed.
 $ eval $(./start.py compose-env --firmware-file-storage-dir path_to_fw_data_dir)
 $ export FACT_DOCKER_POSTGRES_PASSWORD=mypassword
 $ docker volume create fact_postgres_data


### PR DESCRIPTION
Both `FACT_DOCKER_DOCKER_MOUNT_BASE_DIR` and
`FACT_DOCKER_FIRMWARE_FILE_STORAGE_DIR` have to be created by the user.

Closes #38